### PR TITLE
Fix the spelling mistake in the documentation

### DIFF
--- a/MacMeters/DiskIndicator.swift
+++ b/MacMeters/DiskIndicator.swift
@@ -7,13 +7,13 @@
 import Cocoa
 import CoreGraphics
 
-/// Implementation of a MenuBarItem that represent the Disk I/O usage
+/// Implementation of a MenuBarItem that represents the Disk I/O usage
 /// Including a call to 'grep-ed' 'top' command to get the I/O informations
 class DiskIndictator : MenuBarItem {
     
     /**
-        Contructor of the DiskIndictator
-         - Call the MenuBarItem contructor
+        Constructor of the DiskIndictator
+         - Call the MenuBarItem constructor
          - Set the width of the icon image
     */
     override init(){
@@ -94,9 +94,9 @@ class DiskIndictator : MenuBarItem {
     }
     
     /**
-        Get the wrote amount of data by parsing the 'top' command result
+        Get the written amount of data by parsing the 'top' command result
         :param: topResult   String containing the result of the 'top' command
-        :returns: The wrote amount of data on the disk
+        :returns: The written amount of data on the disk
         :note: need to be securized
     */
     func getWriteDisk(topResult: String) -> Int {
@@ -109,7 +109,7 @@ class DiskIndictator : MenuBarItem {
     /**
         Execute the command ``` top -l1 | grep Disks: ``` to get the disk I/O informations
         :returns: The String returned by the standard output of the command 
-        :note: It doesn't look to be the best solution
+        :note: It doesn't seem to be the best solution
     */
     func getTopCommandResult() -> String{
         var output: String = ""

--- a/MacMeters/HelpfullFunctions.swift
+++ b/MacMeters/HelpfullFunctions.swift
@@ -7,15 +7,15 @@
 import Cocoa
 import CoreGraphics
 
-/// This file contains some usefull method that are not natively accessible with Swift.
+/// This file contains some usefull methods that are not natively accessible with Swift.
 
 /**
     Draw a given text on the previously locked image.
-    :param: text    The text to be wrote
+    :param: text    The text to be written
     :param: size    The size of the written text
     :param: color   The color of the written text
-    :param: x       The x position of the beginnig of the text
-    :param: y       The y position of the beginnig of the text
+    :param: x       The x position of the beginning of the text
+    :param: y       The y position of the beginning of the text
     :param: w       The width of the box that contains the text (auto line warpping)
     :param: h       The height of the box that contains the text
     :note: Actually the font is Helvetica by default

--- a/MacMeters/MemoryIndicator.swift
+++ b/MacMeters/MemoryIndicator.swift
@@ -7,7 +7,7 @@
 import Cocoa
 import CoreGraphics
 
-/// Implementation of a MenuBarItem that represent the RAM memory usage
+/// Implementation of a MenuBarItem that represents the RAM memory usage
 /// Including a graph representation of the previous values
 /// Including a Swift-><-ObjectiveC-><-C++ call to get the RAM informations
 class MemoryIndictator : MenuBarItem {
@@ -19,8 +19,8 @@ class MemoryIndictator : MenuBarItem {
     var historic = [[CGFloat]]()
     
     /**
-        Contructor of the MemoryIndicator
-         - Call the MenuBarItem contructor
+        Constructor of the MemoryIndicator
+         - Call the MenuBarItem constructor
          - Set the historic length to the width of the icon image
     */
     override init() {
@@ -30,9 +30,9 @@ class MemoryIndictator : MenuBarItem {
     
     /**
         Update method periodically called by the parent thread to update the MemoryIndictator icon image
-         - clean the image
-         - get/draw the informations on the image
-         - update the statusIcon with the new image
+         - Clean the image
+         - Get/draw the informations on the image
+         - Update the statusIcon with the new image
     */
     override func update(){
         cleanImage()
@@ -90,10 +90,10 @@ class MemoryIndictator : MenuBarItem {
     }
     
     /**
-        Function that update the historic with the given values
+        Function that updates the historic with the given values
         :param: free    free amount of memory to add to the historic
         :param: used    used amount of memory to add to the historic
-        :note: This method also control the size of the historic by removing the old datas
+        :note: This method also controls the size of the historic by removing the old datas
     */
     func updateHistoric(free: CGFloat, used: CGFloat) {
         historic.append([free,used])

--- a/MacMeters/MenuBarItem.swift
+++ b/MacMeters/MenuBarItem.swift
@@ -6,17 +6,17 @@
 
 import Cocoa
 
-/// The MenuBarItem represent an object/indicator that display some information in the Mac status bar.
+/// The MenuBarItem represents an object/indicator that display some informations in the Mac status bar.
 /// These informations are drawn on an image and the image is added as an icon in the status bar
 /// The class is the abstract representation of an indicator
 /// A MenuBarItem implements a thread that makes it independent of the other indicators calcul time
 class MenuBarItem : NSObject {
     
     /// The system object that creates an blank icon in the status bar.
-    /// -1 means that the icon size is vaiable depending of the image displayed
+    /// -1 means that the icon size is variable depending of the image displayed
     let statusIcon = NSStatusBar.systemStatusBar().statusItemWithLength(-1)
     
-    /// Define is the MenuBarItem is enabled or not and eventualy hide the status icon by giving it a size of 0
+    /// Define if the MenuBarItem is enabled or not and eventualy hide the status icon by giving it a size of 0
     var enabled: Bool {
         get{ return self.statusIcon.length == -1}
         set(activated){
@@ -37,7 +37,7 @@ class MenuBarItem : NSObject {
     /// The height of the icon image, by default the height of the status bar
     var height: CGFloat = NSStatusBar.systemStatusBar().thickness
     
-    /// Time between two update of the icon image displaying the informations, by default 1 second
+    /// Time between two updates of the icon image displaying the informations, by default 1 second
     var updateTime: CGFloat = 1
     
     /// The image of the icon
@@ -54,8 +54,8 @@ class MenuBarItem : NSObject {
     
     /**
         Constructor of the MenuBarItem
-         - enable the MenuBarItem
-         - launch the thread
+         - Enable the MenuBarItem
+         - Launch the thread
     */
     override init(){
         super.init()
@@ -93,10 +93,10 @@ class MenuBarItem : NSObject {
     /**
         The function called periodically by the thread.
         This method have to:
-            - get the datas to display
-            - print the datas on the icon image
-            - update the icon image by calling ``` self.statusIcon.image = image ```
-        :note: The method is made abstract by an assert that is launched if the method is not overrrided.
+            - Get the datas to display
+            - Print the datas on the icon image
+            - Update the icon image by calling ``` self.statusIcon.image = image ```
+        :note: The method is made abstract by an assert that is launched if the method is not overridden.
     */
     func update() {
         assert(false, "This method must be overriden by the subclass")

--- a/MacMeters/NetworkIndicator.swift
+++ b/MacMeters/NetworkIndicator.swift
@@ -7,13 +7,13 @@
 import Cocoa
 import CoreGraphics
 
-/// Implementation of a MenuBarItem that represent the network usage
+/// Implementation of a MenuBarItem that represents the network usage
 /// Including a Swift-><-ObjectiveC-><-C++ call to get the network informations
 class NetworkIndictator : MenuBarItem {
     
     /**
-        Contructor of the NetworkIndictator
-        - Call the MenuBarItem contructor
+        Constructor of the NetworkIndictator
+        - Call the MenuBarItem constructor
         - Set the width of the icon image
         - Set the updateTime to 0.5 second
     */
@@ -25,9 +25,9 @@ class NetworkIndictator : MenuBarItem {
     
     /**
         Update method periodically called by the parent thread to update the NetworkIndictator icon image
-        - clean the image
-        - get/draw the informations on the image
-        - update the statusIcon with the new image
+        - Clean the image
+        - Get/draw the informations on the image
+        - Update the statusIcon with the new image
     */
     override func update(){
         cleanImage()

--- a/MacMeters/ProcessorIndicator.swift
+++ b/MacMeters/ProcessorIndicator.swift
@@ -7,7 +7,7 @@
 import Cocoa
 import CoreGraphics
 
-/// Implementation of a MenuBarItem that represent the Processor usage
+/// Implementation of a MenuBarItem that represents the Processor usage
 /// Including a graph representation of the previous values
 /// Including a Swift-><-ObjectiveC-><-C++ call to get the Processor informations
 class ProcessorIndictator : MenuBarItem {
@@ -19,8 +19,8 @@ class ProcessorIndictator : MenuBarItem {
     var historic = [[CGFloat]]()
     
     /**
-        Contructor of the ProcessorIndictator
-         - Call the MenuBarItem contructor
+        Constructor of the ProcessorIndictator
+         - Call the MenuBarItem constructor
          - Set the historic length to the width of the icon image
          - Set the updateTime to 0.5 second
     */
@@ -32,9 +32,9 @@ class ProcessorIndictator : MenuBarItem {
     
     /**
         Update method periodically called by the parent thread to update the ProcessorIndictator icon image
-         - clean the image
-         - get/draw the informations on the image
-         - update the statusIcon with the new image
+         - Clean the image
+         - Get/draw the informations on the image
+         - Update the statusIcon with the new image
     */
     override func update(){
         cleanImage()
@@ -99,10 +99,10 @@ class ProcessorIndictator : MenuBarItem {
     }
     
     /**
-        Function that update the historic with the given values
+        Function that updates the historic with the given values
         :param: user    user percent used amount to add to the historic
         :param: system  system percent used amount to add to the historic
-        :note: This method also control the size of the historic by removing the old datas
+        :note: This method also controls the size of the historic by removing the old datas
     */
     func updateHistoric(user: CGFloat, system: CGFloat) {
         historic.append([user,system])

--- a/MacMeters/cppBridge.h
+++ b/MacMeters/cppBridge.h
@@ -9,7 +9,7 @@
 #ifndef MacMeters_cppBridge_h
 #define MacMeters_cppBridge_h
 
-/// This Objective-C class represent a bridge to the C++ class ``` cppFunctions ```
+/// This Objective-C class represents a bridge to the C++ class ``` cppFunctions ```
 @interface cppFunctionsBridge : NSObject
 + (void) getCpu: (float*) returnTab;
 + (void) getRam: (float*) returnTab;


### PR DESCRIPTION
Hi,

I've fixed few spelling mistakes in the documentation. I have not touched any lines of code so it should not have any impact on the behavior of the program.
